### PR TITLE
Add basic TensorFlow CNN model

### DIFF
--- a/cnn_model.py
+++ b/cnn_model.py
@@ -1,0 +1,22 @@
+import tensorflow as tf
+from tensorflow.keras import layers, models
+
+def create_cnn_model(input_shape=(224, 224, 3), num_classes=2):
+    model = models.Sequential([
+        layers.Input(shape=input_shape),
+        layers.Conv2D(32, (3, 3), activation='relu', padding='same'),
+        layers.MaxPooling2D((2, 2)),
+        layers.Conv2D(64, (3, 3), activation='relu', padding='same'),
+        layers.MaxPooling2D((2, 2)),
+        layers.Conv2D(128, (3, 3), activation='relu', padding='same'),
+        layers.MaxPooling2D((2, 2)),
+        layers.Flatten(),
+        layers.Dense(64, activation='relu'),
+        layers.Dense(num_classes, activation='softmax')
+    ])
+    model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])
+    return model
+
+if __name__ == "__main__":
+    model = create_cnn_model()
+    model.summary()


### PR DESCRIPTION
## Summary
- implement a simple convolutional neural network in `cnn_model.py`

## Testing
- `python cnn_model.py` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_684a140e7fa8832e806f3176652c72fb