### PR TITLE
Add training script and model saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Classificador_Imagens_HP
 Projeto da Sprint 1 para detecção de cartuchos HP falsificados. Criação de dataset de imagens, pré-processamento e treinamento de modelo CNN com Keras/TensorFlow. Classificação binária entre cartuchos originais e falsificados, com avaliação de acurácia e matriz de confusão.
+
+## Treinamento
+Execute `train.py` para carregar as imagens do diretório `dataset`, treinar a rede leve baseada em MobileNetV2 e salvar o modelo resultante no formato Keras (`hp_classifier.h5`). Esse arquivo poderá ser convertido posteriormente para o formato TensorFlow Lite (.tflite).

--- a/train.py
+++ b/train.py
@@ -1,0 +1,51 @@
+import tensorflow as tf
+from tensorflow.keras import layers
+
+
+data_dir = 'dataset'
+img_size = (224, 224)
+batch_size = 16
+
+train_ds = tf.keras.utils.image_dataset_from_directory(
+    data_dir,
+    validation_split=0.2,
+    subset='training',
+    seed=123,
+    image_size=img_size,
+    batch_size=batch_size
+)
+val_ds = tf.keras.utils.image_dataset_from_directory(
+    data_dir,
+    validation_split=0.2,
+    subset='validation',
+    seed=123,
+    image_size=img_size,
+    batch_size=batch_size
+)
+
+AUTOTUNE = tf.data.AUTOTUNE
+train_ds = train_ds.cache().shuffle(1000).prefetch(buffer_size=AUTOTUNE)
+val_ds = val_ds.cache().prefetch(buffer_size=AUTOTUNE)
+
+base_model = tf.keras.applications.MobileNetV2(
+    input_shape=img_size + (3,),
+    include_top=False,
+    weights='imagenet'
+)
+base_model.trainable = False
+
+inputs = tf.keras.Input(shape=img_size + (3,))
+x = tf.keras.applications.mobilenet_v2.preprocess_input(inputs)
+x = base_model(x, training=False)
+x = layers.GlobalAveragePooling2D()(x)
+outputs = layers.Dense(1, activation='sigmoid')(x)
+model = tf.keras.Model(inputs, outputs)
+
+model.compile(optimizer='adam',
+              loss='binary_crossentropy',
+              metrics=['accuracy'])
+
+model.fit(train_ds, epochs=5, validation_data=val_ds)
+
+model.save('hp_classifier.h5')
+print('Model saved to hp_classifier.h5')


### PR DESCRIPTION
## Summary
- add training script using MobileNetV2
- save trained model as `hp_classifier.h5`
- update README with training instructions

## Testing
- `python -m py_compile train.py`

------
https://chatgpt.com/codex/tasks/task_e_684a14cf9288832e994f8a1e7a2a4838