### PR TITLE
Add main pipeline script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Projeto da Sprint 1 para detecção de cartuchos HP falsificados. Criação de dataset de imagens, pré-processamento e treinamento de modelo CNN com Keras/TensorFlow. Classificação binária entre cartuchos originais e falsificados, com avaliação de acurácia e matriz de confusão.
 
 ## Treinamento
-Execute `train.py` para carregar as imagens do diretório `dataset`, treinar a rede leve baseada em MobileNetV2 e salvar o modelo resultante no formato Keras (`hp_classifier.h5`). Esse arquivo poderá ser convertido posteriormente para o formato TensorFlow Lite (.tflite).
+Utilize `main.py` para executar o pipeline completo de carregamento do dataset, treinamento e avaliação do modelo. O script salva o classificador treinado como `hp_classifier.h5`, que pode ser convertido posteriormente para TensorFlow Lite (.tflite).

--- a/cnn_model.py
+++ b/cnn_model.py
@@ -14,7 +14,10 @@ def create_cnn_model(input_shape=(224, 224, 3), num_classes=2):
         layers.Dense(64, activation='relu'),
         layers.Dense(num_classes, activation='softmax')
     ])
-    model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])
+    # Use sparse categorical cross-entropy so labels can be integers
+    model.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
     return model
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -1,0 +1,76 @@
+import os
+import numpy as np
+import tensorflow as tf
+from sklearn.metrics import confusion_matrix, accuracy_score, precision_score, recall_score, f1_score
+
+from cnn_model import create_cnn_model
+
+DATA_DIR = 'dataset'
+IMG_SIZE = (224, 224)
+BATCH_SIZE = 16
+EPOCHS = 5
+VALIDATION_SPLIT = 0.2
+
+
+def load_dataset(data_dir=DATA_DIR, img_size=IMG_SIZE, batch_size=BATCH_SIZE, validation_split=VALIDATION_SPLIT):
+    """Load training and validation datasets."""
+    train_ds = tf.keras.utils.image_dataset_from_directory(
+        data_dir,
+        validation_split=validation_split,
+        subset="training",
+        seed=123,
+        image_size=img_size,
+        batch_size=batch_size,
+    )
+    val_ds = tf.keras.utils.image_dataset_from_directory(
+        data_dir,
+        validation_split=validation_split,
+        subset="validation",
+        seed=123,
+        image_size=img_size,
+        batch_size=batch_size,
+    )
+
+    autotune = tf.data.AUTOTUNE
+    train_ds = train_ds.cache().shuffle(1000).prefetch(buffer_size=autotune)
+    val_ds = val_ds.cache().prefetch(buffer_size=autotune)
+    return train_ds, val_ds
+
+
+def train(model, train_ds, val_ds, epochs=EPOCHS):
+    """Train the model."""
+    history = model.fit(train_ds, epochs=epochs, validation_data=val_ds)
+    return history
+
+
+def evaluate(model, val_ds):
+    """Evaluate the model on the validation dataset and print metrics."""
+    probabilities = model.predict(val_ds)
+    predictions = np.argmax(probabilities, axis=1)
+    labels = np.concatenate([y for _, y in val_ds], axis=0)
+
+    acc = accuracy_score(labels, predictions)
+    prec = precision_score(labels, predictions)
+    rec = recall_score(labels, predictions)
+    f1 = f1_score(labels, predictions)
+
+    print(f"Acur\u00e1cia: {acc:.4f}")
+    print(f"Precis\u00e3o: {prec:.4f}")
+    print(f"Recall: {rec:.4f}")
+    print(f"F1-score: {f1:.4f}")
+
+    cm = confusion_matrix(labels, predictions)
+    print("Matriz de confus\u00e3o:\n", cm)
+
+
+def main():
+    train_ds, val_ds = load_dataset()
+    model = create_cnn_model(num_classes=2)
+    train(model, train_ds, val_ds)
+    evaluate(model, val_ds)
+    model.save('hp_classifier.h5')
+    print('Modelo salvo em hp_classifier.h5')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create a `main.py` orchestrating dataset loading, training and evaluation
- update `cnn_model` to compile with sparse categorical cross-entropy
- update instructions in `README`

## Testing
- `python -m py_compile cnn_model.py load_and_split.py train.py train_cnn.py train_and_evaluate.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684a16bcf7b8832e8129349ca3571fed